### PR TITLE
Rename script.test.js.snap  to script.test.js.snap1

### DIFF
--- a/public/__test__/__snapshots__/script.test.js.snap1
+++ b/public/__test__/__snapshots__/script.test.js.snap1
@@ -1,0 +1,101 @@
+exports[`API October PRs error message 1`] = \
+  `"<div class=\"row\"><div class=\"large-12 columns\"><h2>An error occurred while fetching new issues, \
+  have you set your github token? </h2></div></div>"`;
+
+
+
+exports[`API October PRs success message 1`] = `"Testing!"`;
+
+
+
+exports[`API Username PRs error message 1`] = \
+  `"<div class=\"row\"><div class=\"large-12 columns\"><h2>An error occurred while fetching new issues, \
+  have you set your github token? </h2></div></div>"`;
+
+
+
+exports[`API Username PRs success message 1`] = \
+  `"<div class=\"row\"><div class=\"large-12 columns\"><h2>An error occurred while fetching new issues, \
+  have you set your github token? </h2></div></div>"`;
+
+
+
+exports[`HTML Error markup is approved markup 1`] = `"<div class=\"large-12 columns\"><h2></h2></div>"`;
+
+
+
+exports[`HTML Spinner markup is approved markup 1`] = `"<div class=\"large-12 columns\"><h2>\
+  <img src=\"/img/ajax-loader.gif\" alt=\"loading\"></h2></div>"`;
+
+
+
+exports[`HacktoberfestChecker default properties are set 1`] = `
+
+Array [
+
+  Object {
+
+    "username": Object {
+
+      "isjQuery": true,
+
+      "length": 1,
+
+    },
+
+  },
+
+  Object {
+
+    "openIssues": Object {
+
+      "isjQuery": true,
+
+      "length": 1,
+
+    },
+
+  },
+
+  Object {
+
+    "form": Object {
+
+      "isjQuery": true,
+
+      "length": 1,
+
+    },
+
+  },
+
+  Object {
+
+    "results": Object {
+
+      "isjQuery": true,
+
+      "length": 1,
+
+    },
+
+  },
+
+  Object {
+
+    "errors": "{\"emptyUsername\":\"Username cannot be blank.\", \
+      \"API\":{\"issue\":\"An error occurred while fetching new issues, \
+      have you set your github token? \",\"username\":\"An error occurred while fetching issues for the given username,\
+      have you set your github token? \"}}",
+
+  },
+
+  Object {
+
+    "loader": "\"/img/ajax-loader.gif\"",
+
+  },
+
+]
+
+`;


### PR DESCRIPTION
The preferred way of wrapping long lines is by using implied line continuation inside parentheses, brackets and braces. If necessary, you can add an extra pair of parentheses around an expression, but sometimes using a backslash looks better. ". I altered the code for better readability, as well as fixed indentation for readability as well. All browsers except extremely old ones support the backslash followed by newline approach, and will continue to do so in the future for backward compatibility.
